### PR TITLE
Update radar logging and version retrieval, tweak 'xe125' example

### DIFF
--- a/examples/xe125/.cargo/config.toml
+++ b/examples/xe125/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-rs run --chip STM32L431CBYx --chip-erase --connect-under-reset --verify"
+runner = "probe-rs run --chip STM32L431CBYx --connect-under-reset"
 
 [target.thumbv7em-none-eabihf]
 rustflags = [
@@ -13,7 +13,3 @@ target = "thumbv7em-none-eabihf"
 
 [env]
 DEFMT_LOG = "trace"
-
-[net]
-git-fetch-with-cli = true
-

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -80,7 +80,7 @@ impl AccHalImpl {
     ) {
         let tmp_buf = unsafe { core::slice::from_raw_parts_mut(buffer, buffer_length) };
         trace!(
-            "Transfer16 function called: buffer={:x} (size:{})",
+            "Transfer16 function called: buffer={:#X} (size:{})",
             tmp_buf,
             buffer_length
         );
@@ -90,7 +90,7 @@ impl AccHalImpl {
             let spi = binding.as_mut().unwrap_unchecked();
             // Perform the SPI transfer
             spi.transfer_in_place(tmp_buf).unwrap_unchecked();
-            trace!("Transfer16 function completed, buffer={:x}", tmp_buf);
+            trace!("Transfer16 function completed, buffer={:#X}", tmp_buf);
         });
     }
 

--- a/src/radar.rs
+++ b/src/radar.rs
@@ -22,9 +22,15 @@ where
 
 /// Radar Sensor Software Version
 /// 0xMMMMmmPP where M is major, m is minor and P is patch
-#[derive(Debug, defmt::Format)]
+#[derive(Debug)]
 pub struct RssVersion {
     version: u32,
+}
+
+impl defmt::Format for RssVersion {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}.{}.{}", self.major(), self.minor(), self.patch())
+    }
 }
 
 impl Display for RssVersion {
@@ -43,11 +49,11 @@ impl RssVersion {
     }
 
     pub fn minor(&self) -> u8 {
-        ((self.version & 0x0000FF00) >> 16) as u8
+        ((self.version & 0x0000FF00) >> 8) as u8
     }
 
     pub fn patch(&self) -> u8 {
-        ((self.version & 0x000000FF) >> 8) as u8
+        (self.version & 0x000000FF) as u8
     }
 }
 
@@ -92,9 +98,9 @@ where
     pub fn id(&self) -> u32 {
         self.id
     }
+}
 
-    pub fn version(&self) -> RssVersion {
-        let version = unsafe { acc_version_get_hex() };
-        RssVersion::new(version)
-    }
+pub fn rss_version() -> RssVersion {
+    let version = unsafe { acc_version_get_hex() };
+    RssVersion::new(version)
 }


### PR DESCRIPTION
Changes include updated logging formatting in the hal.rs file, improved version retrieval and printing in radar.rs, and modification of version methods. For the 'xe125' example, removed probe-rs 'verify' flag and defmt log attribute from .cargo/config.toml, added new imported 'radar' structures in main.rs, and adjusted for new version retrieval method.

The `__hardfp_sqrtf` function was also added to main.rs following the `__hardfp_roundf` function, providing the square root of the input float as a return. The same file also discards the optional 'chip-erase' flag and removes git-fetch-with-cli from the net environment in the .cargo/config.toml file.