### PR TITLE
add xe125_armgcc cargo check to CI

### DIFF
--- a/.github/workflows/example-xe125_armgcc.yml
+++ b/.github/workflows/example-xe125_armgcc.yml
@@ -10,7 +10,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-name: no-std
+name: example-xe125_armgcc
 jobs:
   nostd:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds a new workflow which attempts to `cargo check` the xe125 example using the Arm-provided gcc compiler. 