### PR TITLE
Esp updates

### DIFF
--- a/examples/esp32s3-hal/Cargo.lock
+++ b/examples/esp32s3-hal/Cargo.lock
@@ -4,13 +4,13 @@ version = 3
 
 [[package]]
 name = "a121-rs"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "bindgen",
  "cc",
  "defmt",
  "defmt-rtt",
- "embassy-sync 0.5.0 (git+https://github.com/embassy-rs/embassy)",
+ "embassy-sync",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "num",
@@ -307,18 +307,6 @@ checksum = "dd938f25c0798db4280fcd8026bf4c2f48789aebf8f77b6e5cf8a7693ba114ec"
 dependencies = [
  "cfg-if",
  "critical-section",
- "embedded-io-async",
- "futures-util",
- "heapless",
-]
-
-[[package]]
-name = "embassy-sync"
-version = "0.5.0"
-source = "git+https://github.com/embassy-rs/embassy#7718d66053f6b8aef7c5d56652e29d7142eee072"
-dependencies = [
- "cfg-if",
- "critical-section",
  "defmt",
  "embedded-io-async",
  "futures-util",
@@ -507,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e021610c11f106869f382f532fb81de0df98fd2b41299deba81bb62e9c4c4f8"
+checksum = "cc3e9b3333d2ae42f5c9b4890e162cb756fb1b067ab5f642b89fc9f29be424fa"
 dependencies = [
  "basic-toml",
  "bitfield",
@@ -519,7 +507,7 @@ dependencies = [
  "document-features",
  "embassy-executor",
  "embassy-futures",
- "embassy-sync 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "embassy-sync",
  "embassy-time-driver",
  "embedded-can",
  "embedded-dma",

--- a/examples/esp32s3-hal/Cargo.toml
+++ b/examples/esp32s3-hal/Cargo.toml
@@ -9,12 +9,12 @@ license = "MIT OR Apache-2.0"
 debug = true
 
 [dependencies]
-esp-hal = { version = "0.16.0", features = ["async", "eh1", "embassy", "embassy-time-timg0", "embassy-executor-thread", "esp32s3"] }
+esp-hal = { version = "0.16.1", features = ["async", "eh1", "embassy", "embassy-time-timg0", "embassy-executor-thread", "esp32s3"] }
 esp-backtrace = { version = "0.11.0", features = ["esp32s3", "panic-handler", "exception-handler", "println"] }
 esp-println = { version = "0.9.0", features = ["esp32s3", "defmt-espflash"] }
 defmt = "0.3.5"
 
-a121-rs = { path = "../../", features = ["distance"] }
+a121-rs = { path = "../../", features = ["distance", "nightly-logger"] }
 embedded-hal-bus = { version = "0.1.0", features = ["async"] }
 embedded-hal = "1.0.0"
 tinyrlibc = { git = "https://github.com/rust-embedded-community/tinyrlibc.git", version = "0.3.0" }

--- a/examples/esp32s3-hal/src/main.rs
+++ b/examples/esp32s3-hal/src/main.rs
@@ -108,11 +108,11 @@ async fn init(_spawner: Spawner) {
                 if res.num_distances() > 0 {
                     measurements += 1;
                     distances += res.num_distances();
-                    //println!(
-                    //    "{} Distances found:\n{:?}",
-                    //    res.num_distances(),
-                    //    res.distances()
-                    //);
+                    println!(
+                        "{} Distances found:\n{:?}",
+                        res.num_distances(),
+                        res.distances()
+                    );
                 }
                 if res.calibration_needed() {
                     println!("Calibration needed.");

--- a/examples/esp32s3-hal/src/main.rs
+++ b/examples/esp32s3-hal/src/main.rs
@@ -108,11 +108,11 @@ async fn init(_spawner: Spawner) {
                 if res.num_distances() > 0 {
                     measurements += 1;
                     distances += res.num_distances();
-                    println!(
-                        "{} Distances found:\n{:?}",
-                        res.num_distances(),
-                        res.distances()
-                    );
+                    //println!(
+                    //    "{} Distances found:\n{:?}",
+                    //    res.num_distances(),
+                    //    res.distances()
+                    //);
                 }
                 if res.calibration_needed() {
                     println!("Calibration needed.");


### PR DESCRIPTION
Esp now requires/uses the nightly logger due to changes in the latest version of the hal. 