### PR TITLE
Enable defmt on embassy-sync only if defmt is enabled on the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ defmt = { version = "1.0.1", optional = true }
 
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
-embassy-sync = { version = "0.7.2", features = [ "defmt" ] }
+embassy-sync = { version = "0.7.2", features = [] }
 
 num = { version = "0.4", default-features = false }
 libm = { version = "0.2.15", default-features = false, optional = true }
@@ -31,7 +31,7 @@ libm = ["dep:libm", "num/libm"]
 # Recommended if you don't want to have to link a huge chunk of newlib
 nightly-logger = ["defmt"]
 std = []
-defmt = ["dep:defmt"]
+defmt = ["dep:defmt", "embassy-sync/defmt"]
 
 [profile.dev]
 lto = true


### PR DESCRIPTION
Don't enable defmt on embassy-sync all the time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured feature configuration to provide more granular control over optional debugging and logging dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->