### PR TITLE
Bring-up registers, SPI callback HAL, and STM32WBA65RI example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ defmt = { version = "1.0.1", optional = true }
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 embassy-sync = { version = "0.7.2", features = [] }
+critical-section = "1.2"
 
 num = { version = "0.4", default-features = false }
 libm = { version = "0.2.15", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -62,10 +62,31 @@ See the [documentation](https://docs.rs/a121-rs) for detailed usage instructions
 | libm           | Use libm crate for floating point operations                                                                                 |
 | nightly-logger | If the C wrapper for logging does not compile with stable rust, enable this feature to use nightly rust with a custom logger |
 
+## Bring-up registers
+
+The [`bringup`](https://docs.rs/a121-rs/latest/a121_rs/bringup/index.html) module exposes direct
+16-bit ASIC register read/write over SPI (same framing as the RSS library). Useful before calling
+the full radar API:
+
+```rust
+use a121_rs::bringup::{read_asic_id, SpiTransfer};
+
+// After wiring SPI + enable pin:
+let id = read_asic_id(&mut my_spi)?;
+```
+
+[`AccHalImpl::new_with_transfer`](https://docs.rs/a121-rs/latest/a121_rs/hal/struct.AccHalImpl.html#method.new_with_transfer)
+accepts a function-pointer SPI callback for boards where the existing `SpiDevice` HAL is awkward.
+
 ## Examples
 
-Check out the `examples/` directory for demonstrations on how to use _a121-rs_ with various microcontroller units.
-These examples cover basic setups and common use cases to help you get started quickly.
+| Example | Target |
+|---------|--------|
+| `examples/xe121_l433rc` | STM32L433 + XM125 |
+| `examples/stm32wba65ri` | STM32WBA65RI bring-up (ASIC ID + RSS version) |
+| `examples/esp32*` | Espressif |
+
+Set `A121_RSS_LIB` to the directory containing `libacconeer_a121.a` when building firmware examples.
 
 **Note:** For the esp32c6 example, you need to do additional steps before you can compile successfully:
 - Add the static libraries (.a) to the acc folder, you can request these from Acconeer

--- a/examples/stm32wba65ri/.cargo/config.toml
+++ b/examples/stm32wba65ri/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip STM32WBA65RI"
+
+[build]
+target = "thumbv8m.main-none-eabihf"
+
+[env]
+DEFMT_LOG = "info"

--- a/examples/stm32wba65ri/Cargo.toml
+++ b/examples/stm32wba65ri/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "stm32wba65ri-bringup"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+a121-rs = { path = "../..", default-features = false, features = ["defmt"] }
+a121-sys = { path = "../../../a121-sys" }
+
+cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+defmt = "1.0.1"
+defmt-rtt = "1.0.0"
+panic-probe = { version = "1.0.0", features = ["print-defmt"] }
+
+embassy-executor = { version = "0.9.0", features = [
+    "arch-cortex-m",
+    "executor-thread",
+    "defmt",
+] }
+embassy-time = { version = "0.5.0", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-stm32 = { version = "0.4.0", features = [
+    "defmt",
+    "stm32wba65ri",
+    "time-driver-any",
+    "memory-x",
+    "exti",
+] }
+embassy-futures = "0.1.2"
+embedded-hal = "1.0.0"
+embedded-hal-bus = "0.3.0"
+
+linked_list_allocator = "0.10.5"
+
+[profile.release]
+debug = 2
+lto = true
+codegen-units = 1

--- a/examples/stm32wba65ri/README.md
+++ b/examples/stm32wba65ri/README.md
@@ -1,0 +1,25 @@
+# STM32WBA65RI bring-up
+
+Minimal Embassy example: enable sensor, register RSS HAL, read ASIC ID register.
+
+## Wiring (example — adjust for your board)
+
+| Signal  | MCU pin |
+|---------|---------|
+| SPI_SCK | PB3     |
+| SPI_MOSI| PB5     |
+| SPI_MISO| PB4     |
+| SPI_CS  | PA8     |
+| SEN_EN  | PA9     |
+| SEN_INT | PB10    |
+
+## Build
+
+Requires Acconeer static libraries for Cortex-M33:
+
+```bash
+export A121_RSS_LIB=/path/to/rss/lib
+cargo build --release
+```
+
+Headers come from the sibling `a121-sys` crate (`rss/include/`).

--- a/examples/stm32wba65ri/src/main.rs
+++ b/examples/stm32wba65ri/src/main.rs
@@ -1,0 +1,84 @@
+//! A121 bring-up on STM32WBA65RI (Embassy).
+//!
+//! SPI1: SCK PB4, MOSI PA15, MISO PB3, CS PA8, enable PA9.
+
+#![no_std]
+#![no_main]
+
+use a121_rs::bringup::{self, Error as BringupError};
+use a121_rs::hal::AccHalImpl;
+use a121_rs::radar::rss_version;
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
+use embassy_stm32::mode::Blocking;
+use embassy_stm32::spi::{self, Config as SpiConfig, Spi};
+use embassy_stm32::time::Hertz;
+use embassy_time::{Duration, Timer};
+use embedded_hal::spi::{Operation, SpiDevice};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use linked_list_allocator::LockedHeap;
+use {defmt_rtt as _, panic_probe as _};
+
+#[global_allocator]
+static ALLOCATOR: LockedHeap = LockedHeap::empty();
+
+type SpiBus = ExclusiveDevice<
+    Spi<'static, Blocking>,
+    Output<'static>,
+    embassy_time::Delay,
+>;
+
+static mut SPI_BUS: Option<SpiBus> = None;
+
+fn spi_transfer(buffer: &mut [u8]) -> Result<(), BringupError> {
+    let bus = unsafe {
+        (*core::ptr::addr_of_mut!(SPI_BUS))
+            .as_mut()
+            .expect("SPI not initialized")
+    };
+    bus.transaction(&mut [Operation::TransferInPlace(buffer)])
+        .map_err(|_| BringupError::Spi)
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    const HEAP_SIZE: usize = 32 * 1024;
+    static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
+    unsafe { ALLOCATOR.lock().init(HEAP.as_mut_ptr(), HEAP_SIZE) };
+
+    let p = embassy_stm32::init(Default::default());
+
+    info!("A121 STM32WBA65RI bring-up");
+    info!("RSS version: {}", rss_version());
+
+    let mut enable = Output::new(p.PA9, Level::Low, Speed::High);
+    let cs = Output::new(p.PA8, Level::High, Speed::High);
+    let _int_pin = Input::new(p.PB10, Pull::Up);
+
+    let mut spi_cfg = SpiConfig::default();
+    spi_cfg.frequency = Hertz(32_000_000);
+    spi_cfg.mode = spi::MODE_0;
+
+    let spi = Spi::new_blocking(p.SPI1, p.PB4, p.PA15, p.PB3, spi_cfg);
+
+    unsafe {
+        SPI_BUS = Some(ExclusiveDevice::new(spi, cs, embassy_time::Delay).unwrap());
+    }
+
+    enable.set_high();
+    Timer::after(Duration::from_millis(2)).await;
+
+    let hal = AccHalImpl::new_with_transfer(spi_transfer, 65535);
+    hal.register().expect("HAL register");
+
+    match bringup::read_asic_id(&mut bringup::FnSpiTransfer(spi_transfer)) {
+        Ok(id) => info!("ASIC ID: 0x{:04x}", id),
+        Err(e) => error!("ASIC ID read failed: {:?}", e),
+    }
+
+    loop {
+        Timer::after_secs(2).await;
+        info!("heartbeat");
+    }
+}

--- a/src/bringup.rs
+++ b/src/bringup.rs
@@ -1,0 +1,71 @@
+//! Low-level ASIC register access over SPI (bring-up / diagnostics).
+//!
+//! Framing matches the Acconeer RSS library (`addr | 0x3000` read, `addr | 0x1000` write).
+//! This is intentionally small and does not depend on `device-driver`.
+
+/// SPI read command flag (OR with 16-bit register address).
+pub const READ_FLAG: u16 = 0x3000;
+/// SPI write command flag (OR with 16-bit register address).
+pub const WRITE_FLAG: u16 = 0x1000;
+
+/// ASIC identity register (communication / bring-up test).
+pub const REG_ASIC_ID: u16 = 0x004D;
+/// Run status register.
+pub const REG_RUN_STATUS: u16 = 0x0062;
+/// Wakeup status 0.
+pub const REG_WAKEUP_STATUS0: u16 = 0x007C;
+/// Interrupt status register.
+pub const REG_INTERRUPT_STATUS: u16 = 0x0098;
+/// Scratchpad configuration 0.
+pub const REG_SCRATCHPAD_CONFIG0: u16 = 0x0037;
+/// Stack level status.
+pub const REG_STACK_LEVEL_STATUS: u16 = 0x001C;
+
+/// Errors during register-level SPI access.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// SPI transfer failed.
+    Spi,
+}
+
+/// In-place SPI transfer (chip select held for the whole buffer).
+pub trait SpiTransfer {
+    /// Full-duplex transfer used for register transactions.
+    fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Error>;
+}
+
+/// Read a 16-bit ASIC register.
+pub fn read_register<S: SpiTransfer>(spi: &mut S, address: u16) -> Result<u16, Error> {
+    let header = address | READ_FLAG;
+    let mut buf = [0u8; 6];
+    buf[0..2].copy_from_slice(&header.to_le_bytes());
+    spi.transfer_in_place(&mut buf)?;
+    Ok(u16::from_le_bytes([buf[4], buf[5]]))
+}
+
+/// Write a 16-bit ASIC register.
+pub fn write_register<S: SpiTransfer>(spi: &mut S, address: u16, value: u16) -> Result<(), Error> {
+    let header = address | WRITE_FLAG;
+    let mut buf = [0u8; 4];
+    buf[0..2].copy_from_slice(&header.to_le_bytes());
+    buf[2..4].copy_from_slice(&value.to_le_bytes());
+    spi.transfer_in_place(&mut buf)
+}
+
+/// Read the ASIC ID register (sanity check after enable + SPI wiring).
+pub fn read_asic_id<S: SpiTransfer>(spi: &mut S) -> Result<u16, Error> {
+    read_register(spi, REG_ASIC_ID)
+}
+
+/// Adapter for `fn(&mut [u8]) -> Result<(), E>` callbacks (e.g. shared with [`crate::hal::AccHalImpl::new_with_transfer`]).
+pub struct FnSpiTransfer<F>(pub F);
+
+impl<F> SpiTransfer for FnSpiTransfer<F>
+where
+    F: FnMut(&mut [u8]) -> Result<(), Error>,
+{
+    fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Error> {
+        (self.0)(words)
+    }
+}

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -9,6 +9,18 @@ use embassy_sync::blocking_mutex::Mutex;
 use embedded_hal::spi::{ErrorKind as SpiErrorKind, SpiDevice};
 
 use a121_sys::{acc_hal_a121_t, acc_hal_optimization_t, acc_rss_hal_register, acc_sensor_id_t};
+use critical_section::Mutex as CsMutex;
+
+use crate::bringup::Error as BringupError;
+
+extern "C" {
+    fn c_log_stub(
+        level: a121_sys::acc_log_level_t,
+        module: *const c_char,
+        format: *const c_char,
+        ...
+    );
+}
 
 pub type RadarSpi = dyn SpiDevice<u8, Error = SpiErrorKind> + Send;
 pub type RefRadarSpi = &'static mut RadarSpi;
@@ -27,6 +39,10 @@ pub type RefRadarSpi = &'static mut RadarSpi;
 /// and is not accessed after it has been freed or gone out of scope.
 static SPI_INSTANCE: Mutex<CriticalSectionRawMutex, RefCell<Option<RefRadarSpi>>> =
     Mutex::new(RefCell::new(None));
+
+type SpiTransferFn = fn(&mut [u8]) -> Result<(), BringupError>;
+
+static SPI_TRANSFER_FN: CsMutex<RefCell<Option<SpiTransferFn>>> = CsMutex::new(RefCell::new(None));
 
 /// Represents the hardware abstraction layer implementation for the radar sensor.
 ///
@@ -55,10 +71,34 @@ impl AccHalImpl {
             #[cfg(feature = "nightly-logger")]
             log: Some(logger),
             #[cfg(not(feature = "nightly-logger"))]
-            log: Some(a121_sys::c_log_stub),
+            log: Some(c_log_stub),
             optimization: acc_hal_optimization_t { transfer16: None },
         };
         SPI_INSTANCE.lock(|cell| cell.replace(Some(spi)));
+        Self { inner }
+    }
+
+    /// HAL using a plain SPI callback (no `SpiDevice` trait object).
+    ///
+    /// Use this when integrating with `ExclusiveDevice` + `embassy_futures::block_on`, or any
+    /// platform where [`Self::new`] is awkward. Pair with [`crate::bringup`] for register tests.
+    pub fn new_with_transfer(transfer: SpiTransferFn, max_spi_transfer_size: u16) -> Self {
+        critical_section::with(|cs| {
+            SPI_TRANSFER_FN.borrow(cs).replace(Some(transfer));
+        });
+
+        let inner = acc_hal_a121_t {
+            max_spi_transfer_size,
+            mem_alloc: Some(mem_alloc),
+            mem_free: Some(mem_free),
+            transfer: Some(Self::transfer8_from_fn),
+            #[cfg(feature = "nightly-logger")]
+            log: Some(logger),
+            #[cfg(not(feature = "nightly-logger"))]
+            log: Some(c_log_stub),
+            optimization: acc_hal_optimization_t { transfer16: None },
+        };
+
         Self { inner }
     }
 
@@ -100,12 +140,25 @@ impl AccHalImpl {
         buffer_length: usize,
     ) {
         let tmp_buf = unsafe { core::slice::from_raw_parts_mut(buffer, buffer_length) };
-        // Borrow a mutable reference to the SpiBus
         SPI_INSTANCE.lock(|cell| unsafe {
             let mut binding = cell.borrow_mut();
             let spi = binding.as_mut().unwrap_unchecked();
-            // Perform the SPI transfer
             spi.transfer_in_place(tmp_buf).unwrap_unchecked();
+        });
+    }
+
+    extern "C" fn transfer8_from_fn(
+        _sensor_id: acc_sensor_id_t,
+        buffer: *mut u8,
+        buffer_length: usize,
+    ) {
+        let slice = unsafe { core::slice::from_raw_parts_mut(buffer, buffer_length) };
+        critical_section::with(|cs| {
+            let transfer = SPI_TRANSFER_FN
+                .borrow(cs)
+                .borrow()
+                .expect("SPI transfer callback not set");
+            transfer(slice).expect("SPI transfer failed");
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ extern crate std;
 
 extern crate alloc;
 
+/// Low-level ASIC register access for bring-up
+pub mod bringup;
 /// Configuration for the radar sensor
 pub mod config;
 #[cfg(any(feature = "distance", feature = "presence"))]

--- a/src/radar.rs
+++ b/src/radar.rs
@@ -1,5 +1,7 @@
 pub mod version;
 
+pub use version::rss_version;
+
 use a121_sys::{acc_sensor_connected, acc_sensor_id_t, acc_sensor_t};
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorKind as SpiErrorKind, SpiDevice};


### PR DESCRIPTION
## Summary

- Add a small `bringup` module for direct 16-bit ASIC register read/write over SPI (same framing as the RSS library), including `read_asic_id`.
- Add `AccHalImpl::new_with_transfer` for boards where a function-pointer SPI callback is easier than the existing `SpiDevice` trait-object path (e.g. Embassy `ExclusiveDevice` + blocking transfers from RSS C callbacks).
- Add `examples/stm32wba65ri` Embassy bring-up (RSS version + ASIC ID) with SPI1 pinmux for STM32WBA65 / XE121 (SCK PB4, MOSI PA15, MISO PB3, CS PA8, enable PA9).
- Re-export `radar::rss_version` and document bring-up in the README.

Depends on [a121-sys M33 / env support](https://github.com/Ragarnoy/a121-sys) (or equivalent `A121_RSS_*` paths) when building for `thumbv8m.main-none-eabihf`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new STM32WBA65RI bring-up example for initializing the sensor, reading the ASIC ID, and logging status.
  * Exposed additional low-level register access support and a new HAL transfer path for more flexible SPI integration.
  * Re-exported the RSS version for easier access from the radar module.

* **Documentation**
  * Expanded the examples section with a dedicated bring-up guide, wiring notes, and build instructions.
  * Added setup guidance for firmware example builds, including required library path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->